### PR TITLE
Remove space in `getOption('scorecard.bin_close_right')`

### DIFF
--- a/R/condition_fun.R
+++ b/R/condition_fun.R
@@ -351,7 +351,7 @@ brk_txt2vector = function(brk) {
 }
 
 getoption_cutright = function() {
-  cut_right = getOption('scorecard.bin_close_right ')
+  cut_right = getOption('scorecard.bin_close_right')
   if (is.null(cut_right)) cut_right = FALSE
   return(cut_right)
 }


### PR DESCRIPTION
Hi @ShichenXie 

I noted the option have a trailing space so I removed. Then I tested and it worked: 

``` r
library(scorecard)

# options(`scorecard.bin_close_right ` = TRUE)
options(scorecard.bin_close_right = TRUE)

data("germancredit")

bins1 <- woebin(germancredit, y = "creditability", x = c("age.in.years", "duration.in.month"))
#> [INFO] creating woe binning ...
bins1$age.in.years[, c(1, 2, 3)]
#>        variable       bin count
#> 1: age.in.years (-Inf,25]   190
#> 2: age.in.years   (25,27]   101
#> 3: age.in.years   (27,34]   257
#> 4: age.in.years   (34,36]    79
#> 5: age.in.years (36, Inf]   373

bins2 <- woebin(germancredit, y = "creditability")
#> [INFO] creating woe binning ...
bins1$age.in.years[, c(1, 2, 3)]
#>        variable       bin count
#> 1: age.in.years (-Inf,25]   190
#> 2: age.in.years   (25,27]   101
#> 3: age.in.years   (27,34]   257
#> 4: age.in.years   (34,36]    79
#> 5: age.in.years (36, Inf]   373
```

<sup>Created on 2021-05-28 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>


